### PR TITLE
Add modular Wayland configs with dynamic theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# aihype
+# Arch Linux Modular Wayland Setup
+
+This repository contains a modular configuration for a minimal Wayland desktop on Arch Linux.
+
+## Overview
+
+The setup uses **Hyprland** as the compositor with supporting applications:
+
+- **Waybar**: Status bar
+- **Kitty**: Terminal emulator
+- **Fish**: Shell
+- **Fuzzel**: Application launcher
+- **Dunst**: Notification daemon
+
+Dynamic theming is powered by a local LLM via **Ollama**. Colors are extracted from the selected wallpaper and written to `themes/colors.json`. Generated fragments are placed in `~/.cache/theme/` and imported by the individual configs.
+
+Configuration files are stored in `dotfiles/.config` so they can be managed with `stow` or any dotfile manager. Scripts live under `scripts/` and themes under `themes/`.
+
+## Theme Generation Workflow
+
+1. Run `scripts/theme_switcher.sh /path/to/wallpaper.jpg`.
+2. The script sets the wallpaper using `swww` and calls `ollama` to generate a color palette.
+3. Color fragments for Hyprland, Waybar, Kitty, Dunst and Fuzzel are written to `~/.cache/theme/`.
+4. The components are reloaded so the new palette takes effect.
+
+## Keybindings
+
+Key | Action
+----|-------
+Super + Enter | Launch Kitty
+Super + D | Launch Fuzzel
+Super + Q | Close focused window
+Super + Shift + R | Reload Hyprland
+Print | Screenshot using grim + slurp
+
+Brightness and volume keys are handled via `brightnessctl` and `playerctl`.
+
+## Troubleshooting
+
+- Ensure `swww` and `ollama` are installed for wallpaper and color extraction.
+- If colors do not update, remove `~/.cache/theme` and re-run `theme_switcher.sh`.
+

--- a/dotfiles/.config/dunst/dunstrc
+++ b/dotfiles/.config/dunst/dunstrc
@@ -1,0 +1,5 @@
+[global]
+    frame_color = "${accent}"
+    background = "${background}"
+    foreground = "${foreground}"
+    font = Monospace 10

--- a/dotfiles/.config/fish/config.fish
+++ b/dotfiles/.config/fish/config.fish
@@ -1,0 +1,7 @@
+# Fish configuration
+set -g theme_file ~/.cache/theme/colors.env
+if test -f $theme_file
+    source $theme_file
+end
+
+alias ls='ls --color=auto'

--- a/dotfiles/.config/fuzzel/config
+++ b/dotfiles/.config/fuzzel/config
@@ -1,0 +1,4 @@
+[colors]
+background=@background
+text=@foreground
+match=@accent

--- a/dotfiles/.config/hypr/autostart/start.sh
+++ b/dotfiles/.config/hypr/autostart/start.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Autostart services for Hyprland
+
+# Start wallpaper daemon
+if ! pgrep -x swww-daemon >/dev/null; then
+  swww-daemon &
+fi
+
+# Start notification daemon
+if ! pgrep -x dunst >/dev/null; then
+  dunst &
+fi
+
+# Clipboard history
+if ! pgrep -x wl-paste >/dev/null; then
+  wl-paste --type text --watch cliphist store &
+fi
+

--- a/dotfiles/.config/hypr/bindings/keys.conf
+++ b/dotfiles/.config/hypr/bindings/keys.conf
@@ -1,0 +1,19 @@
+# Keybindings for Hyprland
+
+$mod = SUPER
+
+bind = $mod, Return, exec, kitty
+bind = $mod, D, exec, fuzzel
+bind = $mod, Q, killactive,
+bind = $mod SHIFT, R, exec, hyprctl reload
+
+bind = , Print, exec, grim -g "$(slurp)" ~/Pictures/Screenshot-$(date +%s).png
+
+# Volume and brightness
+bindle = , XF86MonBrightnessUp, exec, brightnessctl set +5%
+bindle = , XF86MonBrightnessDown, exec, brightnessctl set 5%-
+bindle = , XF86AudioRaiseVolume, exec, pamixer --increase 5
+bindle = , XF86AudioLowerVolume, exec, pamixer --decrease 5
+bindl = , XF86AudioMute, exec, pamixer --toggle-mute
+bind = , XF86AudioPlay, exec, playerctl play-pause
+

--- a/dotfiles/.config/hypr/hyprland.conf
+++ b/dotfiles/.config/hypr/hyprland.conf
@@ -1,0 +1,12 @@
+# Hyprland main configuration
+source=$HOME/.config/hypr/bindings/keys.conf
+source=$HOME/.config/hypr/autostart/start.sh
+source=$HOME/.config/hypr/ui/theme.conf
+
+input {
+  kb_layout = se
+  numlock_by_default = true
+}
+
+# Window rules and options can be added here
+

--- a/dotfiles/.config/hypr/ui/theme.conf
+++ b/dotfiles/.config/hypr/ui/theme.conf
@@ -1,0 +1,2 @@
+# Theme variables (generated)
+source=$HOME/.cache/theme/colors.conf

--- a/dotfiles/.config/kitty/kitty.conf
+++ b/dotfiles/.config/kitty/kitty.conf
@@ -1,0 +1,4 @@
+include colors.conf
+
+font_family Iosevka
+font_size 11

--- a/dotfiles/.config/waybar/config
+++ b/dotfiles/.config/waybar/config
@@ -1,0 +1,8 @@
+{
+  "layer": "top",
+  "height": 30,
+  "modules-left": ["hyprland/workspaces"],
+  "modules-center": ["clock"],
+  "modules-right": ["pulseaudio", "battery"],
+  "clock": {"format": "%a %H:%M"}
+}

--- a/dotfiles/.config/waybar/style.css
+++ b/dotfiles/.config/waybar/style.css
@@ -1,0 +1,15 @@
+@import url("colors.css");
+
+* {
+    font-family: monospace;
+    font-size: 14px;
+}
+
+window#waybar {
+    background: @background;
+    color: @foreground;
+}
+
+#workspaces button.focused {
+    background: @accent;
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# Install packages
+PACKAGES=(hyprland waybar kitty fish fuzzel dunst swww jq ollama brightnessctl playerctl grim slurp cliphist pamixer)
+
+if command -v paru >/dev/null; then
+  paru -S --needed --noconfirm "${PACKAGES[@]}"
+else
+  sudo pacman -S --needed --noconfirm "${PACKAGES[@]}"
+fi
+
+# Create config directories
+mkdir -p "$HOME/.config"
+
+# Symlink dotfiles (requires GNU stow)
+if command -v stow >/dev/null; then
+  stow -t "$HOME" dotfiles
+else
+  echo "Install 'stow' to manage symlinks" >&2
+fi
+
+# Copy initial theme
+mkdir -p "$HOME/.config/themes"
+cp -n themes/dark/colors.json "$HOME/.config/themes/colors.json"
+
+# Initial theme setup
+scripts/theme_switcher.sh "$HOME/.config/wallpapers/default.jpg" || true

--- a/scripts/theme_switcher.sh
+++ b/scripts/theme_switcher.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Apply wallpaper and generate theme
+
+wall="$1"
+
+if [ -z "$wall" ]; then
+  echo "Usage: theme_switcher.sh /path/to/wallpaper" >&2
+  exit 1
+fi
+
+# ensure cache directory
+mkdir -p "$HOME/.cache/theme"
+
+# set wallpaper
+if ! pgrep -x swww-daemon >/dev/null; then
+  swww-daemon &
+  sleep 1
+fi
+swww img "$wall"
+
+# generate color palette using local LLM via Ollama
+# expected output: JSON with background, foreground and accent keys
+palette=$(ollama run walpal "$wall") || {
+  echo "ollama failed" >&2
+  exit 1
+}
+
+echo "$palette" > "$HOME/.config/themes/colors.json"
+
+# create fragments from palette
+jq -r '. as $c | "$background = \($c.background)\n$foreground = \($c.foreground)\n$accent = \($c.accent)"' "$HOME/.config/themes/colors.json" > "$HOME/.cache/theme/colors.conf"
+
+jq -r '. as $c | "@define-color background \($c.background);\n@define-color foreground \($c.foreground);\n@define-color accent \($c.accent);"' "$HOME/.config/themes/colors.json" > "$HOME/.cache/theme/colors.css"
+
+jq -r '. as $c | "foreground \($c.foreground)\nbackground \($c.background)\ncolor1 \($c.accent)"' "$HOME/.config/themes/colors.json" > "$HOME/.cache/theme/kitty.conf"
+
+# env file for fish or other shells
+jq -r 'to_entries|map("export " + .key | ascii_upcase + "=" + .value) | .[]' "$HOME/.config/themes/colors.json" > "$HOME/.cache/theme/colors.env"
+
+# reload components
+hyprctl reload
+killall -SIGUSR2 waybar 2>/dev/null
+notify-send "Theme updated" "$(basename "$wall")"

--- a/scripts/wall_set.sh
+++ b/scripts/wall_set.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Simple helper to change wallpaper without re-theming
+wall="$1"
+if [ -z "$wall" ]; then
+  echo "Usage: wall_set.sh /path/to/wallpaper" >&2
+  exit 1
+fi
+
+if ! pgrep -x swww-daemon >/dev/null; then
+  swww-daemon &
+  sleep 1
+fi
+swww img "$wall"

--- a/themes/dark/colors.json
+++ b/themes/dark/colors.json
@@ -1,0 +1,5 @@
+{
+  "background": "#1d1f21",
+  "foreground": "#c5c8c6",
+  "accent": "#81a2be"
+}

--- a/themes/light/colors.json
+++ b/themes/light/colors.json
@@ -1,0 +1,5 @@
+{
+  "background": "#fdf6e3",
+  "foreground": "#657b83",
+  "accent": "#268bd2"
+}


### PR DESCRIPTION
## Summary
- provide a repository structure for an Arch Linux Wayland setup
- add Hyprland, Waybar, Kitty, Fish, Fuzzel and Dunst configs
- implement theme generation script using Ollama
- supply example themes and install script
- document workflow and keybindings in README

## Testing
- `bash -n scripts/theme_switcher.sh`
- `bash -n scripts/wall_set.sh`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e2d10568c83218ba845cec21d30f6