### PR TITLE
Add wallpaper picker and randomizer scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The setup uses **Hyprland** as the compositor with supporting applications:
 Dynamic theming is powered by a local LLM via **Ollama**. Colors are extracted from the selected wallpaper and written to `themes/colors.json`. Generated fragments are placed in `~/.cache/theme/` and imported by the individual configs.
 
 Configuration files are stored in `dotfiles/.config` so they can be managed with `stow` or any dotfile manager. Scripts live under `scripts/` and themes under `themes/`.
+Additional utilities handle wallpaper management and theming.
 
 ## Theme Generation Workflow
 
@@ -22,6 +23,15 @@ Configuration files are stored in `dotfiles/.config` so they can be managed with
 2. The script sets the wallpaper using `swww` and calls `ollama` to generate a color palette.
 3. Color fragments for Hyprland, Waybar, Kitty, Dunst and Fuzzel are written to `~/.cache/theme/`.
 4. The components are reloaded so the new palette takes effect.
+
+## Wallpaper Selection
+
+Use `scripts/wallpaper_picker.sh` to browse wallpapers with previews and apply
+them together with a freshly generated theme. Wallpapers are looked up in
+`~/Pictures/wallpapers` by default but a directory can be provided as an
+argument. A helper `scripts/random_wallpaper.sh` picks a random image from the
+same location and re-generates the theme automatically.
+
 
 ## Keybindings
 
@@ -38,5 +48,6 @@ Brightness and volume keys are handled via `brightnessctl` and `playerctl`.
 ## Troubleshooting
 
 - Ensure `swww` and `ollama` are installed for wallpaper and color extraction.
+- `fzf` is required for the wallpaper picker.
 - If colors do not update, remove `~/.cache/theme` and re-run `theme_switcher.sh`.
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Install packages
-PACKAGES=(hyprland waybar kitty fish fuzzel dunst swww jq ollama brightnessctl playerctl grim slurp cliphist pamixer)
+PACKAGES=(hyprland waybar kitty fish fuzzel dunst swww jq ollama brightnessctl playerctl grim slurp cliphist pamixer fzf)
 
 if command -v paru >/dev/null; then
   paru -S --needed --noconfirm "${PACKAGES[@]}"

--- a/scripts/random_wallpaper.sh
+++ b/scripts/random_wallpaper.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Set a random wallpaper from a directory and generate a matching theme
+set -euo pipefail
+
+DIR="${1:-$HOME/Pictures/wallpapers}"
+
+if [ ! -d "$DIR" ]; then
+  echo "Wallpaper directory '$DIR' not found" >&2
+  exit 1
+fi
+
+wall=$(find "$DIR" -maxdepth 1 -type f \( -iname "*.jpg" -o -iname "*.png" -o -iname "*.jpeg" -o -iname "*.webp" \) | shuf -n 1)
+
+if [ -n "$wall" ]; then
+  "$(dirname "$0")/theme_switcher.sh" "$wall"
+fi

--- a/scripts/wallpaper_picker.sh
+++ b/scripts/wallpaper_picker.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Select a wallpaper with preview using fzf and kitty icat
+set -euo pipefail
+
+DIR="${1:-$HOME/Pictures/wallpapers}"
+
+if [ ! -d "$DIR" ]; then
+  echo "Wallpaper directory '$DIR' not found" >&2
+  exit 1
+fi
+
+cd "$DIR"
+
+preview='kitty +kitten icat --clear --transfer-mode=file --stdin=no {}'
+
+choice=$(find . -maxdepth 1 -type f \( -iname "*.jpg" -o -iname "*.png" -o -iname "*.jpeg" -o -iname "*.webp" \) \
+  | sort | fzf --prompt="Select wallpaper > " \
+        --preview="$preview" --preview-window=right:60%)
+
+if [ -n "$choice" ]; then
+  "$(dirname "$0")/theme_switcher.sh" "$DIR/${choice#./}"
+fi


### PR DESCRIPTION
## Summary
- expand install script dependencies
- add wallpaper picker using fzf and kitty previews
- add random wallpaper helper
- document new utilities in README
- include empty wallpapers directory

## Testing
- `bash -n install.sh`
- `bash -n scripts/theme_switcher.sh`
- `bash -n scripts/wall_set.sh`
- `bash -n scripts/wallpaper_picker.sh`
- `bash -n scripts/random_wallpaper.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e2ee40f988321bdcec522d871dec8