### PR TITLE
Enhance dotfiles and theming workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arch Linux Modular Wayland Setup
 
-This repository contains a modular configuration for a minimal Wayland desktop on Arch Linux.
+This repository contains a modular configuration for a minimal Wayland desktop on Arch Linux.  It now includes helper scripts and presets for a fully automated theming workflow.
 
 ## Overview
 
@@ -17,12 +17,25 @@ Dynamic theming is powered by a local LLM via **Ollama**. Colors are extracted f
 Configuration files are stored in `dotfiles/.config` so they can be managed with `stow` or any dotfile manager. Scripts live under `scripts/` and themes under `themes/`.
 Additional utilities handle wallpaper management and theming.
 
+## Installation
+
+Clone the repository and run:
+
+```bash
+./install.sh
+```
+
+This installs required packages, symlinks all dotfiles and places the helper scripts in `~/.local/bin`.
+After installation the default dark theme is applied.
+
 ## Theme Generation Workflow
 
 1. Run `scripts/theme_switcher.sh /path/to/wallpaper.jpg`.
 2. The script sets the wallpaper using `swww` and calls `ollama` to generate a color palette.
 3. Color fragments for Hyprland, Waybar, Kitty, Dunst and Fuzzel are written to `~/.cache/theme/`.
 4. The components are reloaded so the new palette takes effect.
+
+Detailed steps and keybindings are described in [docs/WORKFLOW.md](docs/WORKFLOW.md).
 
 ## Wallpaper Selection
 
@@ -41,6 +54,8 @@ Super + Enter | Launch Kitty
 Super + D | Launch Fuzzel
 Super + Q | Close focused window
 Super + Shift + R | Reload Hyprland
+Super + T | Toggle preset theme
+Super + P | Wallpaper picker
 Print | Screenshot using grim + slurp
 
 Brightness and volume keys are handled via `brightnessctl` and `playerctl`.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,28 @@
+# Workflow
+
+This guide explains how the pieces of the repository work together.
+
+1. **Install**
+   - Clone the repository and run `./install.sh`.
+   - Packages are installed and dotfiles are symlinked using `stow`.
+   - All helper scripts are linked to `~/.local/bin` so they are available in your `$PATH`.
+   - A default theme is copied to `~/.config/themes/colors.json` and `apply_colors.sh` generates fragments used by the configs.
+
+2. **Theming**
+   - `theme_switcher.sh /path/to/image.jpg` sets the wallpaper and uses a local LLM via `ollama` to create a palette. The palette is saved to `~/.config/themes/colors.json` and `apply_colors.sh` updates fragments.
+   - `toggle_theme.sh` quickly switches between the built in light and dark themes without contacting the LLM.
+   - Generated fragments are stored under `~/.cache/theme/` and sourced by Hyprland, Waybar, Kitty, Dunst and Fuzzel.
+
+3. **Wallpaper Management**
+   - `wallpaper_picker.sh` provides an interactive picker with previews.
+   - `random_wallpaper.sh` applies a random image from your wallpaper directory and generates a matching palette.
+
+4. **Autostart**
+   - When Hyprland launches it executes `autostart/start.sh` which starts required services, loads Waybar and reapplies the current theme.
+
+5. **Keybindings**
+   - Super+T toggles the preset theme.
+   - Super+P opens the wallpaper picker.
+   - Number keys switch workspaces, while Super+Shift moves the focused window.
+
+Together these components provide a lightweight but flexible Wayland desktop with dynamic theming.

--- a/dotfiles/.config/fish/config.fish
+++ b/dotfiles/.config/fish/config.fish
@@ -5,3 +5,15 @@ if test -f $theme_file
 end
 
 alias ls='ls --color=auto'
+
+# Ensure scripts from this repo are in PATH
+set -gx PATH $PATH $HOME/.local/bin
+
+# Convenience functions
+function theme-toggle
+    toggle_theme.sh
+end
+
+function wall-random
+    random_wallpaper.sh
+end

--- a/dotfiles/.config/hypr/autostart/start.sh
+++ b/dotfiles/.config/hypr/autostart/start.sh
@@ -16,3 +16,13 @@ if ! pgrep -x wl-paste >/dev/null; then
   wl-paste --type text --watch cliphist store &
 fi
 
+# Start waybar
+if ! pgrep -x waybar >/dev/null; then
+  waybar &
+fi
+
+# Apply current theme on login
+if [ -f "$HOME/.config/themes/colors.json" ]; then
+  apply_colors.sh "$HOME/.config/themes/colors.json" &
+fi
+

--- a/dotfiles/.config/hypr/bindings/keys.conf
+++ b/dotfiles/.config/hypr/bindings/keys.conf
@@ -7,6 +7,22 @@ bind = $mod, D, exec, fuzzel
 bind = $mod, Q, killactive,
 bind = $mod SHIFT, R, exec, hyprctl reload
 
+bind = $mod, T, exec, toggle_theme.sh
+bind = $mod, P, exec, wallpaper_picker.sh
+
+# Workspace navigation
+bind = $mod, 1, workspace, 1
+bind = $mod, 2, workspace, 2
+bind = $mod, 3, workspace, 3
+bind = $mod, 4, workspace, 4
+bind = $mod, 5, workspace, 5
+
+bind = $mod SHIFT, 1, movetoworkspace, 1
+bind = $mod SHIFT, 2, movetoworkspace, 2
+bind = $mod SHIFT, 3, movetoworkspace, 3
+bind = $mod SHIFT, 4, movetoworkspace, 4
+bind = $mod SHIFT, 5, movetoworkspace, 5
+
 bind = , Print, exec, grim -g "$(slurp)" ~/Pictures/Screenshot-$(date +%s).png
 
 # Volume and brightness

--- a/dotfiles/.config/hypr/hyprland.conf
+++ b/dotfiles/.config/hypr/hyprland.conf
@@ -8,5 +8,22 @@ input {
   numlock_by_default = true
 }
 
+general {
+  gaps_in = 5
+  gaps_out = 20
+  border_size = 2
+  col.active_border = $accent
+  layout = dwindle
+}
+
+decoration {
+  rounding = 6
+}
+
+# Example floating rule
+windowrulev2 = float,class:^(pavucontrol)$
+
+monitor=,preferred,auto,1
+
 # Window rules and options can be added here
 

--- a/dotfiles/.config/waybar/config
+++ b/dotfiles/.config/waybar/config
@@ -3,6 +3,8 @@
   "height": 30,
   "modules-left": ["hyprland/workspaces"],
   "modules-center": ["clock"],
-  "modules-right": ["pulseaudio", "battery"],
-  "clock": {"format": "%a %H:%M"}
+  "modules-right": ["cpu", "memory", "pulseaudio", "battery", "tray"],
+  "clock": {"format": "%a %d %b %H:%M"},
+  "cpu": {"format": "CPU {usage}%"},
+  "memory": {"format": "RAM {used:0.1f}G"}
 }

--- a/dotfiles/.config/waybar/style.css
+++ b/dotfiles/.config/waybar/style.css
@@ -13,3 +13,11 @@ window#waybar {
 #workspaces button.focused {
     background: @accent;
 }
+
+#cpu, #memory, #tray {
+    padding: 0 8px;
+}
+
+#clock {
+    padding: 0 12px;
+}

--- a/install.sh
+++ b/install.sh
@@ -24,5 +24,14 @@ fi
 mkdir -p "$HOME/.config/themes"
 cp -n themes/dark/colors.json "$HOME/.config/themes/colors.json"
 
+# Install helper scripts to ~/.local/bin
+mkdir -p "$HOME/.local/bin"
+for s in scripts/*.sh; do
+  ln -sf "$(pwd)/$s" "$HOME/.local/bin/$(basename "$s")"
+done
+
+# Apply default colors
+scripts/apply_colors.sh "$HOME/.config/themes/colors.json"
+
 # Initial theme setup
 scripts/theme_switcher.sh "$HOME/.config/wallpapers/default.jpg" || true

--- a/scripts/apply_colors.sh
+++ b/scripts/apply_colors.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Generate color fragments from a theme JSON and reload components
+set -euo pipefail
+
+THEME_JSON="${1:-$HOME/.config/themes/colors.json}"
+CACHE_DIR="$HOME/.cache/theme"
+
+mkdir -p "$CACHE_DIR"
+
+# Hyprland fragment
+jq -r '. as $c | "$background = \($c.background)\n$foreground = \($c.foreground)\n$accent = \($c.accent)"' "$THEME_JSON" > "$CACHE_DIR/colors.conf"
+
+# GTK/Waybar colors
+jq -r '. as $c | "@define-color background \($c.background);\n@define-color foreground \($c.foreground);\n@define-color accent \($c.accent);"' "$THEME_JSON" > "$CACHE_DIR/colors.css"
+
+# Kitty colors
+jq -r '. as $c | "foreground \($c.foreground)\nbackground \($c.background)\ncolor1 \($c.accent)"' "$THEME_JSON" > "$CACHE_DIR/kitty.conf"
+
+# Env file for shells
+jq -r 'to_entries|map("export " + (.key | ascii_upcase) + "=" + .value) | .[]' "$THEME_JSON" > "$CACHE_DIR/colors.env"
+
+# Reload components that support live theming
+hyprctl reload >/dev/null 2>&1 || true
+killall -SIGUSR2 waybar 2>/dev/null || true

--- a/scripts/theme_switcher.sh
+++ b/scripts/theme_switcher.sh
@@ -27,17 +27,6 @@ palette=$(ollama run walpal "$wall") || {
 
 echo "$palette" > "$HOME/.config/themes/colors.json"
 
-# create fragments from palette
-jq -r '. as $c | "$background = \($c.background)\n$foreground = \($c.foreground)\n$accent = \($c.accent)"' "$HOME/.config/themes/colors.json" > "$HOME/.cache/theme/colors.conf"
+"$(dirname "$0")/apply_colors.sh" "$HOME/.config/themes/colors.json"
 
-jq -r '. as $c | "@define-color background \($c.background);\n@define-color foreground \($c.foreground);\n@define-color accent \($c.accent);"' "$HOME/.config/themes/colors.json" > "$HOME/.cache/theme/colors.css"
-
-jq -r '. as $c | "foreground \($c.foreground)\nbackground \($c.background)\ncolor1 \($c.accent)"' "$HOME/.config/themes/colors.json" > "$HOME/.cache/theme/kitty.conf"
-
-# env file for fish or other shells
-jq -r 'to_entries|map("export " + .key | ascii_upcase + "=" + .value) | .[]' "$HOME/.config/themes/colors.json" > "$HOME/.cache/theme/colors.env"
-
-# reload components
-hyprctl reload
-killall -SIGUSR2 waybar 2>/dev/null
 notify-send "Theme updated" "$(basename "$wall")"

--- a/scripts/toggle_theme.sh
+++ b/scripts/toggle_theme.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Toggle between the light and dark preset themes
+set -euo pipefail
+
+THEMES_DIR="$(dirname "$0")/../themes"
+CURRENT="$HOME/.config/themes/colors.json"
+mkdir -p "$(dirname "$CURRENT")"
+
+if [ ! -f "$CURRENT" ]; then
+  cp "$THEMES_DIR/dark/colors.json" "$CURRENT"
+  next="dark"
+else
+  bg=$(jq -r '.background' "$CURRENT" 2>/dev/null || echo "")
+  if [ "$bg" = "#fdf6e3" ]; then
+    cp "$THEMES_DIR/dark/colors.json" "$CURRENT"
+    next="dark"
+  else
+    cp "$THEMES_DIR/light/colors.json" "$CURRENT"
+    next="light"
+  fi
+fi
+
+"$(dirname "$0")/apply_colors.sh" "$CURRENT"
+notify-send "Theme switched" "$next"


### PR DESCRIPTION
## Summary
- add helper script `apply_colors.sh`
- create `toggle_theme.sh` for quick theme switching
- update `theme_switcher.sh` to reuse `apply_colors.sh`
- install scripts to `~/.local/bin` and apply default theme in `install.sh`
- expand Hyprland configs and keybindings
- start waybar and apply theme on login
- update Waybar modules and styling
- extend Fish configuration
- document the workflow in `docs/WORKFLOW.md`
- enhance README with installation and keybindings

## Testing
- `bash -n scripts/*.sh dotfiles/.config/hypr/autostart/start.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e30740c048321bf572420f759cd1d