### PR TITLE
Enhance dotfiles and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The setup uses **Hyprland** as the compositor with supporting applications:
 Dynamic theming is powered by a local LLM via **Ollama**. Colors are extracted from the selected wallpaper and written to `themes/colors.json`. Generated fragments are placed in `~/.cache/theme/` and imported by the individual configs.
 
 Configuration files are stored in `dotfiles/.config` so they can be managed with `stow` or any dotfile manager. Scripts live under `scripts/` and themes under `themes/`.
-Additional utilities handle wallpaper management and theming.
+Additional utilities handle wallpaper management and theming. See [docs/DOTFILES.md](docs/DOTFILES.md) for a description of the provided configs.
 
 ## Installation
 

--- a/docs/DOTFILES.md
+++ b/docs/DOTFILES.md
@@ -1,0 +1,29 @@
+# Dotfiles Overview
+
+The `dotfiles` directory holds configuration files for all components of the desktop. They are intended to be managed with `stow` so the structure mirrors `~/.config`.
+
+## Fish shell
+
+`config.fish` loads theme variables from `~/.cache/theme/colors.env`, defines a custom prompt and a few aliases.
+
+## Dunst
+
+The `dunstrc` file styles notifications and sets timeouts. Colors are substituted from the current theme on login.
+
+## Fuzzel
+
+The launcher configuration sets font, width and prompt options under `[main]`.
+
+## Hyprland
+
+- `hyprland.conf` contains global compositor settings and includes keybindings and autostart scripts.
+- `bindings/keys.conf` lists keybindings.
+- `autostart/start.sh` starts services like `swww`, `dunst` and `waybar`.
+
+## Kitty
+
+`kitty.conf` pulls in colors from `~/.cache/theme/kitty.conf` and tweaks window behaviour.
+
+## Waybar
+
+A JSON configuration and accompanying `style.css` control the status bar. `colors.css` is kept in sync with the generated theme by `apply_colors.sh`.

--- a/dotfiles/.config/dunst/dunstrc
+++ b/dotfiles/.config/dunst/dunstrc
@@ -1,5 +1,23 @@
 [global]
+    # Colors are filled in by apply_colors.sh at login
     frame_color = "${accent}"
     background = "${background}"
     foreground = "${foreground}"
+
     font = Monospace 10
+    width = 300
+    origin = top-right
+    offset = 10x40
+    transparency = 15
+    corner_radius = 6
+    markup = full
+
+[urgency_low]
+    timeout = 3
+
+[urgency_normal]
+    timeout = 6
+
+[urgency_critical]
+    timeout = 0
+    frame_color = "#ff5555"

--- a/dotfiles/.config/fish/config.fish
+++ b/dotfiles/.config/fish/config.fish
@@ -5,6 +5,19 @@ if test -f $theme_file
 end
 
 alias ls='ls --color=auto'
+alias grep='grep --color=auto'
+
+# No greeting banner
+set fish_greeting
+
+# Common environment
+set -gx EDITOR nvim
+
+function fish_prompt
+    set_color $accent
+    echo -n (prompt_pwd) '>'
+    set_color normal
+end
 
 # Ensure scripts from this repo are in PATH
 set -gx PATH $PATH $HOME/.local/bin

--- a/dotfiles/.config/fuzzel/config
+++ b/dotfiles/.config/fuzzel/config
@@ -1,3 +1,10 @@
+[main]
+font=Iosevka:size=12
+lines=10
+width=40
+prompt=run: 
+terminal=kitty
+
 [colors]
 background=@background
 text=@foreground

--- a/dotfiles/.config/hypr/autostart/start.sh
+++ b/dotfiles/.config/hypr/autostart/start.sh
@@ -11,6 +11,14 @@ if ! pgrep -x dunst >/dev/null; then
   dunst &
 fi
 
+# Network applet and authentication agent
+if command -v nm-applet >/dev/null && ! pgrep -f nm-applet >/dev/null; then
+  nm-applet &
+fi
+if command -v lxpolkit >/dev/null && ! pgrep -f lxpolkit >/dev/null; then
+  lxpolkit &
+fi
+
 # Clipboard history
 if ! pgrep -x wl-paste >/dev/null; then
   wl-paste --type text --watch cliphist store &

--- a/dotfiles/.config/hypr/bindings/keys.conf
+++ b/dotfiles/.config/hypr/bindings/keys.conf
@@ -10,6 +10,10 @@ bind = $mod SHIFT, R, exec, hyprctl reload
 bind = $mod, T, exec, toggle_theme.sh
 bind = $mod, P, exec, wallpaper_picker.sh
 
+# System helpers
+bind = $mod, L, exec, loginctl lock-session
+bind = $mod SHIFT, N, exec, nm-connection-editor
+
 # Workspace navigation
 bind = $mod, 1, workspace, 1
 bind = $mod, 2, workspace, 2

--- a/dotfiles/.config/hypr/hyprland.conf
+++ b/dotfiles/.config/hypr/hyprland.conf
@@ -13,15 +13,20 @@ general {
   gaps_out = 20
   border_size = 2
   col.active_border = $accent
+  col.inactive_border = 0x444444ff
   layout = dwindle
 }
 
 decoration {
   rounding = 6
+  blur = true
 }
 
 # Example floating rule
 windowrulev2 = float,class:^(pavucontrol)$
+windowrulev2 = float,class:^(nm-connection-editor)$
+
+animation = windows, 1, 3, default
 
 monitor=,preferred,auto,1
 

--- a/dotfiles/.config/kitty/kitty.conf
+++ b/dotfiles/.config/kitty/kitty.conf
@@ -1,4 +1,6 @@
-include colors.conf
+include ~/.cache/theme/kitty.conf
 
 font_family Iosevka
 font_size 11
+background_opacity 0.95
+enable_audio_bell no

--- a/dotfiles/.config/waybar/colors.css
+++ b/dotfiles/.config/waybar/colors.css
@@ -1,0 +1,1 @@
+@import url("../../.cache/theme/colors.css");

--- a/dotfiles/.config/waybar/config
+++ b/dotfiles/.config/waybar/config
@@ -3,8 +3,10 @@
   "height": 30,
   "modules-left": ["hyprland/workspaces"],
   "modules-center": ["clock"],
-  "modules-right": ["cpu", "memory", "pulseaudio", "battery", "tray"],
+  "modules-right": ["cpu", "memory", "disk", "network", "pulseaudio", "battery", "tray"],
   "clock": {"format": "%a %d %b %H:%M"},
   "cpu": {"format": "CPU {usage}%"},
-  "memory": {"format": "RAM {used:0.1f}G"}
+  "memory": {"format": "RAM {used:0.1f}G"},
+  "disk": {"format": "SSD {percentage_used}%"},
+  "network": {"format": "{ifname} {ipaddr}"}
 }

--- a/dotfiles/.config/waybar/style.css
+++ b/dotfiles/.config/waybar/style.css
@@ -1,5 +1,7 @@
 @import url("colors.css");
 
+/* Generated colors.css is symlinked to ~/.cache/theme/colors.css */
+
 * {
     font-family: monospace;
     font-size: 14px;
@@ -14,7 +16,7 @@ window#waybar {
     background: @accent;
 }
 
-#cpu, #memory, #tray {
+#cpu, #memory, #disk, #network, #tray {
     padding: 0 8px;
 }
 

--- a/scripts/apply_colors.sh
+++ b/scripts/apply_colors.sh
@@ -13,6 +13,9 @@ jq -r '. as $c | "$background = \($c.background)\n$foreground = \($c.foreground)
 # GTK/Waybar colors
 jq -r '. as $c | "@define-color background \($c.background);\n@define-color foreground \($c.foreground);\n@define-color accent \($c.accent);"' "$THEME_JSON" > "$CACHE_DIR/colors.css"
 
+# Keep Waybar config in sync
+ln -sf "$CACHE_DIR/colors.css" "$HOME/.config/waybar/colors.css"
+
 # Kitty colors
 jq -r '. as $c | "foreground \($c.foreground)\nbackground \($c.background)\ncolor1 \($c.accent)"' "$THEME_JSON" > "$CACHE_DIR/kitty.conf"
 


### PR DESCRIPTION
## Summary
- document the various config files in a new `DOTFILES.md`
- link the new documentation from the README
- expand Fish shell config with a custom prompt and extra aliases
- extend Dunst, Fuzzel, Kitty and Waybar configurations
- add more autostart tasks and keybindings for Hyprland
- keep Waybar colors synced in `apply_colors.sh`

## Testing
- `bash -n install.sh`
- `for f in scripts/*.sh dotfiles/.config/hypr/autostart/start.sh; do bash -n $f; done`

------
https://chatgpt.com/codex/tasks/task_e_685e40ae39f88321981341edaa6ea093