### PR TITLE
Add dual Waybar mission control

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ See [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md) for the complete list.
 - `fzf` is required for the wallpaper picker.
 - If colors do not update, remove `~/.cache/theme` and re-run `theme_switcher.sh`.
 
+
+For a feature-rich dual Waybar setup, see [docs/ADVANCED_WAYBAR.md](docs/ADVANCED_WAYBAR.md).

--- a/docs/ADVANCED_WAYBAR.md
+++ b/docs/ADVANCED_WAYBAR.md
@@ -1,0 +1,44 @@
+# Advanced Dual Waybar
+
+This configuration provides two Waybar instances acting as a command deck and diagnostics bar.
+
+## Bars
+
+```
+ +------------------------------------------------------------+
+ | Workspaces | Active Window | Mode | Visualizer | Calendar |
+ +------------------------------------------------------------+
+ | CPU | GPU | RAM | Processes | Net | Battery | VPN | TMUX |
+ | Game | Pomodoro | Alerts | Errors |
+ +------------------------------------------------------------+
+```
+
+Top bar (Command Deck) focuses on window management and quick actions. Bottom bar (Diagnostics) displays system metrics.
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `active_window.sh` | Shows active window class and title |
+| `wm_mode.sh` | Indicates tiling/float or editor mode |
+| `audio_visualizer.sh` | ASCII volume visualizer |
+| `calendar_agenda.sh` | Displays date and sends calendar on click |
+| `cpu_chart.sh` | CPU usage sparkline |
+| `gpu_stats.sh` | NVIDIA GPU stats if available |
+| `memory_chart.sh` | Memory usage sparkline |
+| `process_hogs.sh` | Reports top CPU/memory processes |
+| `net_stats.sh` | Net throughput and packet loss |
+| `battery_health.sh` | Battery level and health estimate |
+| `vpn_toggle.sh` | Click to toggle WireGuard VPN with latency |
+| `tmux_tracker.sh` | Count tmux and ssh sessions |
+| `game_mode.sh` | Toggle game mode overlay |
+| `pomodoro_timer.sh` | Simple Pomodoro timer |
+| `error_log.sh` | Last system error log line |
+| `ai_chat.sh` | Launch ChatGPT shell when clicked |
+| `modprobe_loader.sh` | Fuzzy load kernel modules |
+| `background_tasks.sh` | Warn about temperature spikes |
+| `hotplug_reconfigure.sh` | Reload Waybar on monitor hotplug |
+
+Scripts exit gracefully and use `notify-send` for warnings.
+
+Place all scripts in `~/.config/waybar/scripts` and ensure they are executable.

--- a/dotfiles/.config/waybar/config
+++ b/dotfiles/.config/waybar/config
@@ -1,12 +1,94 @@
-{
-  "layer": "top",
-  "height": 30,
-  "modules-left": ["hyprland/workspaces"],
-  "modules-center": ["clock"],
-  "modules-right": ["cpu", "memory", "disk", "network", "pulseaudio", "battery", "tray"],
-  "clock": {"format": "%a %d %b %H:%M"},
-  "cpu": {"format": "CPU {usage}%"},
-  "memory": {"format": "RAM {used:0.1f}G"},
-  "disk": {"format": "SSD {percentage_used}%"},
-  "network": {"format": "{ifname} {ipaddr}"}
-}
+[
+  {
+    "name": "top",
+    "layer": "top",
+    "position": "top",
+    "height": 28,
+    "modules-left": ["hyprland/workspaces"],
+    "modules-center": ["custom/active_window", "custom/wm_mode"],
+    "modules-right": ["custom/audio_visualizer", "custom/calendar", "tray", "custom/ai_chat"]
+  },
+  {
+    "name": "bottom",
+    "layer": "top",
+    "position": "bottom",
+    "height": 28,
+    "modules-left": ["custom/cpu_chart", "custom/gpu_stats", "custom/memory_chart"],
+    "modules-center": ["custom/process_hogs", "custom/net_stats"],
+    "modules-right": ["custom/battery", "custom/vpn", "custom/tmux", "custom/game_mode", "custom/pomodoro", "custom/background_tasks", "custom/error_log"]
+  },
+
+  "custom/active_window": {
+    "exec": "~/.config/waybar/scripts/active_window.sh",
+    "interval": 1
+  },
+  "custom/wm_mode": {
+    "exec": "~/.config/waybar/scripts/wm_mode.sh",
+    "interval": 2
+  },
+  "custom/audio_visualizer": {
+    "exec": "~/.config/waybar/scripts/audio_visualizer.sh",
+    "interval": 1
+  },
+  "custom/calendar": {
+    "exec": "~/.config/waybar/scripts/calendar_agenda.sh",
+    "on-click": "~/.config/waybar/scripts/calendar_agenda.sh click",
+    "interval": 60
+  },
+  "custom/ai_chat": {
+    "exec": "echo AI",
+    "on-click": "~/.config/waybar/scripts/ai_chat.sh"
+  },
+  "custom/cpu_chart": {
+    "exec": "~/.config/waybar/scripts/cpu_chart.sh",
+    "interval": 2
+  },
+  "custom/gpu_stats": {
+    "exec": "~/.config/waybar/scripts/gpu_stats.sh",
+    "interval": 5
+  },
+  "custom/memory_chart": {
+    "exec": "~/.config/waybar/scripts/memory_chart.sh",
+    "interval": 5
+  },
+  "custom/process_hogs": {
+    "exec": "~/.config/waybar/scripts/process_hogs.sh",
+    "interval": 5
+  },
+  "custom/net_stats": {
+    "exec": "~/.config/waybar/scripts/net_stats.sh",
+    "interval": 2,
+    "on-click": "kitty -e traceroute 8.8.8.8"
+  },
+  "custom/battery": {
+    "exec": "~/.config/waybar/scripts/battery_health.sh",
+    "interval": 60
+  },
+  "custom/vpn": {
+    "exec": "~/.config/waybar/scripts/vpn_toggle.sh",
+    "on-click": "~/.config/waybar/scripts/vpn_toggle.sh toggle",
+    "interval": 10
+  },
+  "custom/tmux": {
+    "exec": "~/.config/waybar/scripts/tmux_tracker.sh",
+    "interval": 5
+  },
+  "custom/game_mode": {
+    "exec": "~/.config/waybar/scripts/game_mode.sh",
+    "on-click": "~/.config/waybar/scripts/game_mode.sh toggle",
+    "interval": 2
+  },
+  "custom/pomodoro": {
+    "exec": "~/.config/waybar/scripts/pomodoro_timer.sh",
+    "on-click": "~/.config/waybar/scripts/pomodoro_timer.sh toggle",
+    "interval": 1
+  },
+  "custom/background_tasks": {
+    "exec": "~/.config/waybar/scripts/background_tasks.sh",
+    "interval": 5
+  },
+  "custom/error_log": {
+    "exec": "~/.config/waybar/scripts/error_log.sh",
+    "interval": 30
+  }
+]

--- a/dotfiles/.config/waybar/scripts/active_window.sh
+++ b/dotfiles/.config/waybar/scripts/active_window.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Show active window class and title
+set -euo pipefail
+
+if ! command -v hyprctl >/dev/null; then
+  echo "hyprctl missing" && exit 1
+fi
+
+info=$(hyprctl activewindow -j 2>/dev/null || true)
+if [ -z "$info" ]; then
+  echo "No window"
+  exit 0
+fi
+class=$(echo "$info" | jq -r '.class' 2>/dev/null || echo "?")
+title=$(echo "$info" | jq -r '.title' 2>/dev/null || echo "?")
+
+printf '%s: %s' "$class" "$title"

--- a/dotfiles/.config/waybar/scripts/ai_chat.sh
+++ b/dotfiles/.config/waybar/scripts/ai_chat.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Launch AI chat client
+set -euo pipefail
+
+if command -v chatgpt-shell >/dev/null; then
+  exec chatgpt-shell
+else
+  notify-send "AI Chat" "chatgpt-shell not installed"
+fi

--- a/dotfiles/.config/waybar/scripts/audio_visualizer.sh
+++ b/dotfiles/.config/waybar/scripts/audio_visualizer.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Simple audio visualizer using pulseaudio volume level
+set -euo pipefail
+
+if ! command -v pamixer >/dev/null; then
+  echo "no audio" && exit 0
+fi
+
+vol=$(pamixer --get-volume 2>/dev/null || echo 0)
+bars=$((vol / 5))
+printf 'vol['
+for i in $(seq 0 19); do
+  if [ $i -lt $bars ]; then printf '#'; else printf '.'; fi
+done
+printf ']'

--- a/dotfiles/.config/waybar/scripts/background_tasks.sh
+++ b/dotfiles/.config/waybar/scripts/background_tasks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Monitor background tasks like high temp or fan issues
+set -euo pipefail
+
+alerts=""
+if sensors >/dev/null 2>&1; then
+  temp=$(sensors | awk '/Package id 0:/ {print $4}' | tr -d '+°C')
+  if [ -n "$temp" ] && [ "$temp" -gt 90 ]; then
+    alerts="HOT";
+  fi
+fi
+
+echo "$alerts"

--- a/dotfiles/.config/waybar/scripts/battery_health.sh
+++ b/dotfiles/.config/waybar/scripts/battery_health.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Battery health and predicted life
+set -euo pipefail
+
+if ! command -v upower >/dev/null; then
+  echo "no battery" && exit 0
+fi
+
+device=$(upower -e | grep BAT | head -n1)
+if [ -z "$device" ]; then
+  echo "no battery" && exit 0
+fi
+
+percent=$(upower -i "$device" | awk '/percentage/ {print $2}')
+health=$(upower -i "$device" | awk '/energy-full:/ {full=$2} /energy-full-design/ {design=$2} END { if (design>0) printf "%.0f%%", 100*full/design }')
+
+echo "bat ${percent} health:${health}"

--- a/dotfiles/.config/waybar/scripts/calendar_agenda.sh
+++ b/dotfiles/.config/waybar/scripts/calendar_agenda.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Display date and show calendar on click
+set -euo pipefail
+
+if [ "${1:-}" = "click" ]; then
+  (notify-send "Agenda" "$(cal)" &)
+  exit 0
+fi
+
+date '+%Y-%m-%d'

--- a/dotfiles/.config/waybar/scripts/cpu_chart.sh
+++ b/dotfiles/.config/waybar/scripts/cpu_chart.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# CPU usage with simple sparkline
+set -euo pipefail
+
+prev_total=0
+prev_idle=0
+read cpu user nice system idle iowait irq softirq steal guest guest_nice < /proc/stat
+prev_total=$((user+nice+system+idle+iowait+irq+softirq+steal))
+prev_idle=$idle
+sleep 0.5
+read cpu user nice system idle iowait irq softirq steal guest guest_nice < /proc/stat
+new_total=$((user+nice+system+idle+iowait+irq+softirq+steal))
+new_idle=$idle
+usage=$((100*(new_total-prev_total - (new_idle-prev_idle))/(new_total-prev_total)))
+
+bars=$((usage / 5))
+printf 'cpu['
+for i in $(seq 0 19); do
+  if [ $i -lt $bars ]; then printf '#'; else printf '.'; fi
+done
+printf ']'

--- a/dotfiles/.config/waybar/scripts/error_log.sh
+++ b/dotfiles/.config/waybar/scripts/error_log.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Show last few lines of system log
+set -euo pipefail
+
+journalctl -p err -n 1 --no-pager 2>/dev/null | tail -n 1

--- a/dotfiles/.config/waybar/scripts/game_mode.sh
+++ b/dotfiles/.config/waybar/scripts/game_mode.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Toggle game mode indicator
+set -euo pipefail
+
+state_file="$HOME/.cache/game_mode"
+
+if [ "${1:-}" = "toggle" ]; then
+  if [ -f "$state_file" ]; then
+    rm -f "$state_file"
+    notify-send "Game Mode" "Off"
+  else
+    touch "$state_file"
+    notify-send "Game Mode" "On"
+  fi
+  exit 0
+fi
+
+if [ -f "$state_file" ]; then
+  echo "GAME"
+fi

--- a/dotfiles/.config/waybar/scripts/gpu_stats.sh
+++ b/dotfiles/.config/waybar/scripts/gpu_stats.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# GPU load, fan speed and power
+set -euo pipefail
+
+if command -v nvidia-smi >/dev/null; then
+  line=$(nvidia-smi --query-gpu=utilization.gpu,fan.speed,power.draw --format=csv,noheader,nounits 2>/dev/null | head -n1)
+  if [ -n "$line" ]; then
+    util=$(echo $line | cut -d',' -f1)
+    fan=$(echo $line | cut -d',' -f2)
+    power=$(echo $line | cut -d',' -f3)
+    echo "GPU ${util}% ${fan}% ${power}W"
+  fi
+else
+  echo "GPU N/A"
+fi

--- a/dotfiles/.config/waybar/scripts/hotplug_reconfigure.sh
+++ b/dotfiles/.config/waybar/scripts/hotplug_reconfigure.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Rebuild waybar on monitor hotplug
+set -euo pipefail
+
+swaymsg -t subscribe '["output"]' | while read -r _; do
+  pkill -SIGUSR2 waybar
+done

--- a/dotfiles/.config/waybar/scripts/memory_chart.sh
+++ b/dotfiles/.config/waybar/scripts/memory_chart.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# RAM usage sparkline
+set -euo pipefail
+
+mem_total=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+mem_available=$(grep MemAvailable /proc/meminfo | awk '{print $2}')
+used=$((mem_total - mem_available))
+usage=$((100*used/mem_total))
+bars=$((usage/5))
+printf 'ram['
+for i in $(seq 0 19); do
+  if [ $i -lt $bars ]; then printf '#'; else printf '.'; fi
+done
+printf ']'

--- a/dotfiles/.config/waybar/scripts/modprobe_loader.sh
+++ b/dotfiles/.config/waybar/scripts/modprobe_loader.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Interactive modprobe loader
+set -euo pipefail
+
+module=$(ls /lib/modules/$(uname -r)/kernel | fzf --prompt="Load module > " 2>/dev/null)
+if [ -n "$module" ]; then
+  sudo modprobe "$module" && notify-send "Module loaded" "$module"
+fi

--- a/dotfiles/.config/waybar/scripts/net_stats.sh
+++ b/dotfiles/.config/waybar/scripts/net_stats.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Network speed with packet loss
+set -euo pipefail
+
+iface=$(ip route get 1 | awk '{print $5; exit}')
+rx_prev=$(cat /sys/class/net/$iface/statistics/rx_bytes)
+tx_prev=$(cat /sys/class/net/$iface/statistics/tx_bytes)
+sleep 1
+rx_now=$(cat /sys/class/net/$iface/statistics/rx_bytes)
+tx_now=$(cat /sys/class/net/$iface/statistics/tx_bytes)
+rx_rate=$(( (rx_now-rx_prev)/1024 ))
+tx_rate=$(( (tx_now-tx_prev)/1024 ))
+
+loss=""
+if command -v ping >/dev/null; then
+  loss=$(ping -c 4 -q 8.8.8.8 2>/dev/null | awk -F',' '/packet loss/{print $3}' | tr -d ' ')
+fi
+
+echo "net ${rx_rate}K/${tx_rate}K ${loss}"

--- a/dotfiles/.config/waybar/scripts/pomodoro_timer.sh
+++ b/dotfiles/.config/waybar/scripts/pomodoro_timer.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Simple pomodoro timer
+set -euo pipefail
+
+state_dir="$HOME/.cache/pomodoro"
+mkdir -p "$state_dir"
+start_file="$state_dir/start"
+
+if [ "${1:-}" = "toggle" ]; then
+  if [ -f "$start_file" ]; then
+    rm -f "$start_file"
+    notify-send "Pomodoro" "Stopped"
+  else
+    date +%s > "$start_file"
+    notify-send "Pomodoro" "Started"
+  fi
+  exit 0
+fi
+
+if [ -f "$start_file" ]; then
+  start=$(cat "$start_file")
+  now=$(date +%s)
+  remain=$((1500 - (now - start)))
+  if [ $remain -le 0 ]; then
+    rm -f "$start_file"
+    notify-send "Pomodoro" "Time's up" && exit 0
+  fi
+  mins=$((remain/60))
+  secs=$((remain%60))
+  printf '%02d:%02d' "$mins" "$secs"
+fi

--- a/dotfiles/.config/waybar/scripts/process_hogs.sh
+++ b/dotfiles/.config/waybar/scripts/process_hogs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Show top CPU and memory consuming process names
+set -euo pipefail
+
+ps -eo pid,comm,%cpu,%mem --sort=-%cpu | head -n 2 | tail -n 1 | awk '{printf "cpu:%s %s%%", $2, $3}'
+ps -eo pid,comm,%cpu,%mem --sort=-%mem | head -n 2 | tail -n 1 | awk '{printf " mem:%s %s%%", $2, $4}'

--- a/dotfiles/.config/waybar/scripts/tmux_tracker.sh
+++ b/dotfiles/.config/waybar/scripts/tmux_tracker.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Display number of tmux/ssh sessions
+set -euo pipefail
+
+sessions=$(tmux ls 2>/dev/null | wc -l)
+ssh_sessions=$(pgrep ssh | wc -l)
+
+echo "tmux:${sessions} ssh:${ssh_sessions}"

--- a/dotfiles/.config/waybar/scripts/vpn_toggle.sh
+++ b/dotfiles/.config/waybar/scripts/vpn_toggle.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Toggle VPN connection and report latency
+set -euo pipefail
+
+VPN_IF="wg0"
+
+if [ "${1:-}" = "toggle" ]; then
+  if ip link show "$VPN_IF" >/dev/null 2>&1; then
+    sudo wg-quick down "$VPN_IF" && notify-send "VPN" "Disconnected"
+  else
+    sudo wg-quick up "$VPN_IF" && notify-send "VPN" "Connected"
+  fi
+  exit 0
+fi
+
+status="off"
+if ip link show "$VPN_IF" >/dev/null 2>&1; then
+  status="on"
+  latency=$(ping -c1 -w1 8.8.8.8 2>/dev/null | awk -F'/' 'END{print $5 "ms"}')
+  echo "vpn $status $latency"
+else
+  echo "vpn $status"
+fi

--- a/dotfiles/.config/waybar/scripts/wm_mode.sh
+++ b/dotfiles/.config/waybar/scripts/wm_mode.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Display WM mode: tiling or floating; or editor mode if $EDITOR_MODE set
+set -euo pipefail
+
+mode=${EDITOR_MODE:-}
+if [ -n "$mode" ]; then
+  echo "$mode"
+  exit 0
+fi
+
+if ! command -v hyprctl >/dev/null; then
+  echo "?"
+  exit 0
+fi
+state=$(hyprctl activeworkspace -j 2>/dev/null | jq -r '.floating' 2>/dev/null || echo "")
+if [ "$state" = "true" ]; then
+  echo "float"
+else
+  echo "tile"
+fi

--- a/dotfiles/.config/waybar/style.css
+++ b/dotfiles/.config/waybar/style.css
@@ -1,25 +1,46 @@
 @import url("colors.css");
-
-/* Generated colors.css is symlinked to ~/.cache/theme/colors.css */
-
+/* Futuristic dual bar theme */
 * {
     font-family: monospace;
-    font-size: 14px;
+    font-size: 13px;
 }
 
 window#waybar {
-    background: @background;
+    background: rgba(20,20,20,0.8);
     color: @foreground;
+}
+
+window#waybar.top {
+    border-bottom: 1px solid @accent;
+}
+
+window#waybar.bottom {
+    border-top: 1px solid @accent;
 }
 
 #workspaces button.focused {
     background: @accent;
+    color: @background;
 }
 
-#cpu, #memory, #disk, #network, #tray {
+#tray menu {
+    background: rgba(40,40,40,0.9);
+}
+
+.module {
     padding: 0 8px;
+    transition: background 0.3s;
 }
 
-#clock {
-    padding: 0 12px;
+.module:hover {
+    background: rgba(60,60,60,0.5);
+}
+
+@keyframes alert {
+    from {background-color: @accent;}
+    to {background-color: transparent;}
+}
+
+.module.urgent {
+    animation: alert 1s infinite alternate;
 }


### PR DESCRIPTION
## Summary
- overhaul waybar with two bars and many custom modules
- add interactive scripts backing each module
- provide futuristic css styling
- document modules and new features

## Testing
- `bash -n dotfiles/.config/waybar/scripts/*.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e4712c4f483218c9baebc93ea4b54